### PR TITLE
Fix HTML typo in apply.html

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -19,7 +19,7 @@
   <h2>Application Form</h2>
 
 
-  < form id="applyForm">
+  <form id="applyForm">
     <label>Full Name:
       <input type="text" name="name" required>
     </label>


### PR DESCRIPTION
Corrects a typo in the <form> tag in the application form. The tag was written as `< form` with a space, which prevented the JavaScript from attaching a submit event listener.

This change ensures that the placeholder alert for payment integration is correctly triggered when the form is submitted.